### PR TITLE
libopkg: fix package flags on upgrade

### DIFF
--- a/libopkg/opkg_upgrade.c
+++ b/libopkg/opkg_upgrade.c
@@ -74,7 +74,8 @@ int opkg_upgrade_pkg(pkg_t * old)
 
 	free(old_version);
 	free(new_version);
-	new->state_flag |= SF_USER;
+	new->auto_installed = old->auto_installed;
+	new->state_flag |= old->state_flag & SF_USER;
 	return opkg_install_pkg(new, 1);
 }
 


### PR DESCRIPTION
Previously the auto_installed flag was cleared and the user flag was set whenever a package is upgraded. This prevented upgraded dependent packages from being removed with --autoremove.

This patch preserves the auto_installed and user flags when a package is upgraded enabling dependent packages to be identified as such after upgrade.

Fixes: #4